### PR TITLE
fixing order of drawn sprites

### DIFF
--- a/spork/main.py
+++ b/spork/main.py
@@ -8,7 +8,7 @@ from screens.workshop_screen import workshop_loop
 # Initialise pygame stuff.
 pygame.init()
 clock = pygame.time.Clock()
-built_sprites = pygame.sprite.Group()
+built_sprites = pygame.sprite.OrderedUpdates()
 display_width = 1000
 display_height = 700
 game_surface = pygame.display.set_mode((display_width, display_height))

--- a/spork/screens/result_screen.py
+++ b/spork/screens/result_screen.py
@@ -219,7 +219,7 @@ def result_loop(game_state):
     company = game_state.get('company_name')
 
     # Main group of sprites to display.
-    all_sprites = pygame.sprite.Group()
+    all_sprites = pygame.sprite.OrderedUpdates()
     newspaper = NewspaperSprite(300, 150, company, product)
     all_sprites.add(newspaper)
 

--- a/spork/screens/splicer_screen.py
+++ b/spork/screens/splicer_screen.py
@@ -13,7 +13,7 @@ black= (0,0,0)
 red = (255,0 ,0, 0)
 brown = (139,69,19)
 dark_brown= (111,54,10)
-splice_sprites = pygame.sprite.Group()
+splice_sprites = pygame.sprite.OrderedUpdates()
 
 def load_buttons(game_state):
     splice_sprites.add(

--- a/spork/screens/workshop_screen.py
+++ b/spork/screens/workshop_screen.py
@@ -54,7 +54,7 @@ def remove_workbench_item(game_state):
 
 
 # Main group of sprites to display.
-all_sprites = pygame.sprite.Group()
+all_sprites = pygame.sprite.OrderedUpdates()
 all_sprites.add(
     ButtonSprite(50, 50, 'Splice!', switch_to_screen, ['splicer_screen']),
     ButtonSprite(50, 100, 'QUIT', quit_game, []),


### PR DESCRIPTION
`pygame.sprite.Group` doesn't guarantee the order sprites will be drawn in, `pygame.sprite.OrderedUpdates` is a subclass of `Group` which does.

Have checked on Beth's machine, seems to work :)